### PR TITLE
Feature/accurate cycles

### DIFF
--- a/src/sysc/core2sc_adapter.h
+++ b/src/sysc/core2sc_adapter.h
@@ -114,7 +114,7 @@ public:
             auto cycle_incr = owner->get_last_bus_cycles();
             if(cycle_incr > 1)
                 this->instr_if.update_last_instr_cycles(cycle_incr);
-            owner->sync(this->instr_if.get_total_cycles());
+            owner->qk_sync(this->instr_if.get_total_cycles());
         }
         first = false;
     }
@@ -275,7 +275,9 @@ public:
             if(clk_if && duration > sc_core::SC_ZERO_TIME) {
                 auto cycles = duration.value() / clk_if->read().value();
                 this->reg.cycle += cycles;
+                SCCINFO(owner->hier_name()) << "Increasing cycles by " << cycles << " after WFI";
             }
+            owner->qk_reset(this->instr_if.get_total_cycles());
         };
         owner->exec_on_sysc(f);
         wfi_inst.store(false, std::memory_order_relaxed);

--- a/src/sysc/core2sc_adapter.h
+++ b/src/sysc/core2sc_adapter.h
@@ -270,12 +270,12 @@ public:
                 if(is_debugger_stop_evt)
                     break;
             }
-            SCCINFO(this->owner->hier_name()) << "Got WFI event";
+            SCCDEBUG(this->owner->hier_name()) << "Got WFI event";
             auto duration = sc_core::sc_time_stamp() - start;
             if(clk_if && duration > sc_core::SC_ZERO_TIME) {
                 auto cycles = duration.value() / clk_if->read().value();
                 this->reg.cycle += cycles;
-                SCCINFO(owner->hier_name()) << "Increasing cycles by " << cycles << " after WFI";
+                SCCDEBUG(owner->hier_name()) << "Increasing cycles by " << cycles << " after WFI";
             }
             owner->qk_reset(this->instr_if.get_total_cycles());
         };

--- a/src/sysc/core_complex.cpp
+++ b/src/sysc/core_complex.cpp
@@ -437,15 +437,18 @@ bool core_complex<BUSWIDTH, QK>::read_mem(const addr_t& addr, unsigned length, u
         auto transport_start = sc_core::sc_time_stamp();
         exec_b_transport(gp, delay, is_fetch);
         auto transport_time = sc_core::sc_time_stamp() - transport_start;
-        auto time_taken = (delay + sc_core::sc_time_stamp()) - (pre_delay + transport_start);
+        auto completion = delay + sc_core::sc_time_stamp();
+        auto time_taken = (completion) - (pre_delay + transport_start);
         auto incr = time_taken.value() / curr_clk.read().value();
         if(is_fetch)
             ibus_inc += incr;
         else
             dbus_inc += incr;
 
-        if(transport_time.value())
-            quantum_keeper.reset();
+        if(transport_time.value()) {
+            quantum_keeper.reset(completion);
+            qk_preaccounted_cycles += incr;
+        }
         SCCTRACE(this->name()) << "[local offset: +" << delay << "]: finish read_mem(0x" << std::hex << addr.val << ") : 0x"
                                << (length == 4   ? *(uint32_t*)data
                                    : length == 2 ? *(uint16_t*)data
@@ -502,12 +505,15 @@ bool core_complex<BUSWIDTH, QK>::write_mem(const addr_t& addr, unsigned length, 
         auto transport_start = sc_core::sc_time_stamp();
         exec_b_transport(gp, delay);
         auto transport_time = sc_core::sc_time_stamp() - transport_start;
-        auto time_taken = (delay + sc_core::sc_time_stamp()) - (pre_delay + transport_start);
+        auto completion = delay + sc_core::sc_time_stamp();
+        auto time_taken = (completion) - (pre_delay + transport_start);
         auto incr = time_taken.value() / curr_clk.read().value();
         dbus_inc += incr;
 
-        if(transport_time.value())
-            quantum_keeper.reset();
+        if(transport_time.value()) {
+            quantum_keeper.reset(completion);
+            qk_preaccounted_cycles += incr;
+        }
         SCCTRACE(this->name()) << "[local offset: +" << delay << "]: finish write_mem(0x" << std::hex << addr.val << ") : 0x"
                                << (length == 4   ? *(uint32_t*)data
                                    : length == 2 ? *(uint16_t*)data

--- a/src/sysc/core_complex.cpp
+++ b/src/sysc/core_complex.cpp
@@ -434,16 +434,18 @@ bool core_complex<BUSWIDTH, QK>::read_mem(const addr_t& addr, unsigned length, u
             gp.set_extension<sysc::memspace::tlm_memspace_extension<>>(nullptr);
         };
         auto pre_delay = delay;
+        auto transport_start = sc_core::sc_time_stamp();
         exec_b_transport(gp, delay, is_fetch);
-        if(pre_delay > delay) {
+        auto transport_time = sc_core::sc_time_stamp() - transport_start;
+        auto time_taken = (delay + sc_core::sc_time_stamp()) - (pre_delay + transport_start);
+        auto incr = time_taken.value() / curr_clk.read().value();
+        if(is_fetch)
+            ibus_inc += incr;
+        else
+            dbus_inc += incr;
+
+        if(transport_time.value())
             quantum_keeper.reset();
-        } else {
-            auto incr = (delay - quantum_keeper.get_local_time()) / curr_clk;
-            if(is_fetch)
-                ibus_inc += incr;
-            else
-                dbus_inc += incr;
-        }
         SCCTRACE(this->name()) << "[local offset: +" << delay << "]: finish read_mem(0x" << std::hex << addr.val << ") : 0x"
                                << (length == 4   ? *(uint32_t*)data
                                    : length == 2 ? *(uint16_t*)data
@@ -497,11 +499,15 @@ bool core_complex<BUSWIDTH, QK>::write_mem(const addr_t& addr, unsigned length, 
             gp.set_extension<sysc::memspace::tlm_memspace_extension<>>(nullptr);
         };
         auto pre_delay = delay;
+        auto transport_start = sc_core::sc_time_stamp();
         exec_b_transport(gp, delay);
-        if(pre_delay > delay)
+        auto transport_time = sc_core::sc_time_stamp() - transport_start;
+        auto time_taken = (delay + sc_core::sc_time_stamp()) - (pre_delay + transport_start);
+        auto incr = time_taken.value() / curr_clk.read().value();
+        dbus_inc += incr;
+
+        if(transport_time.value())
             quantum_keeper.reset();
-        else
-            dbus_inc += (delay - quantum_keeper.get_local_time()) / curr_clk;
         SCCTRACE(this->name()) << "[local offset: +" << delay << "]: finish write_mem(0x" << std::hex << addr.val << ") : 0x"
                                << (length == 4   ? *(uint32_t*)data
                                    : length == 2 ? *(uint16_t*)data

--- a/src/sysc/core_complex.h
+++ b/src/sysc/core_complex.h
@@ -43,6 +43,7 @@
 #include <scc/tick2time.h>
 #include <scc/traceable.h>
 #include <scc/utilities.h>
+#include <sysc/kernel/sc_simcontext.h>
 #include <sysc/kernel/sc_time.h>
 #include <tlm/scc/initiator_mixin.h>
 #include <tlm/scc/quantum_keeper.h>
@@ -184,9 +185,13 @@ public:
         return mem_incr > 1 ? mem_incr : 1;
     }
 
-    void sync(uint64_t cycle) override {
+    void qk_sync(uint64_t cycle) override {
         auto core_inc = curr_clk * (cycle - last_sync_cycle);
         quantum_keeper.check_and_sync(core_inc);
+        last_sync_cycle = cycle;
+    }
+    void qk_reset(uint64_t cycle) override {
+        quantum_keeper.reset(sc_core::sc_time_stamp());
         last_sync_cycle = cycle;
     }
 

--- a/src/sysc/core_complex.h
+++ b/src/sysc/core_complex.h
@@ -186,12 +186,16 @@ public:
     }
 
     void qk_sync(uint64_t cycle) override {
-        auto core_inc = curr_clk * (cycle - last_sync_cycle);
+        auto cycle_delta = cycle - last_sync_cycle;
+        auto preaccounted = std::min(cycle_delta, qk_preaccounted_cycles);
+        qk_preaccounted_cycles -= preaccounted;
+        assert(qk_preaccounted_cycles <= cycle_delta);
+        auto core_inc = curr_clk * (cycle_delta - preaccounted);
         quantum_keeper.check_and_sync(core_inc);
         last_sync_cycle = cycle;
     }
     void qk_reset(uint64_t cycle) override {
-        quantum_keeper.reset(sc_core::sc_time_stamp());
+        quantum_keeper.reset(quantum_keeper.get_local_absolute_time());
         last_sync_cycle = cycle;
     }
 
@@ -305,6 +309,7 @@ protected:
     //
     ///////////////////////////////////////////////////////////////////////////////
     uint64_t last_sync_cycle = 0;
+    uint64_t qk_preaccounted_cycles{0};
     util::range_lut<tlm_dmi_ext> fetch_lut{tlm_dmi_ext()};
     util::range_lut<tlm_dmi_ext>& get_read_lut(unsigned space) {
         return space < dmi_read_luts.size() ? dmi_read_luts[space] : get_lut(dmi_read_luts, space);

--- a/src/sysc/core_complex_if.h
+++ b/src/sysc/core_complex_if.h
@@ -61,7 +61,9 @@ struct core_complex_if {
     virtual unsigned get_last_bus_cycles() = 0;
 
     //! Allow quantum keeper handling
-    virtual void sync(uint64_t) = 0;
+    virtual void qk_sync(uint64_t) = 0;
+
+    virtual void qk_reset(uint64_t) = 0;
 
     util::delegate<void(std::function<void(void)>&)> exec_on_sysc;
 


### PR DESCRIPTION
This PR aims to correct the drift of the mcycle register across simulation.
Goal is such that `mcycle * period = simulation time`

When using multicore setup, at any point in time the `mcycle` registers is should be the same across all cores